### PR TITLE
la maltufa does not implement the official parser.

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
 <h3>Available versions</h3>
 <p><a href="./camxes.html">la camxes, a version closer to the official grammar</a></p>
-<p><a href="http://guskant.github.io/gerna_cipra/maltufa-1.1.html">la maltufa, another parser trying to implement the official grammar</a></p>
+<p><a href="http://guskant.github.io/gerna_cipra/maltufa-1.1.html">la maltufa, an unofficial parser to parse most part of the old corpus according to the official grammar before <a href="https://groups.google.com/d/msg/bpfk-list/OH-sdfvlXsY/WZU1OpAEfFkJ">Decemper 27 2014</a></p>
 <p><a href="./camxes-exp.html">la camxes, an experimental unofficial grammar version</a></p>
 
 <h3>Requirements</h3>


### PR DESCRIPTION
 The grammar is different from the official one in priperties of SA and mekso.