### PR TITLE
Add gloss and loop options to run_camxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Here is the list of possible letters and their associated meaning:
 * R -> Raw output, do not prune the tree, except the morphology if 'M' not present.
 * J -> JSON output
 * G -> Replace words by glosses
+* L -> Run the parser in a loop, consume every input line terminated by a newline and output parsed result
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Here is the list of possible letters and their associated meaning:
 * J -> JSON output
 * G -> Replace words by glosses
 * L -> Run the parser in a loop, consume every input line terminated by a newline and output parsed result
+* L -> A second 'L' means that run_camxes will expect every input line to begin with a mode string (possibly empty) followed by a space, after which the actual input follows.
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Here is the list of possible letters and their associated meaning:
 * N -> Show main node labels
 * R -> Raw output, do not prune the tree, except the morphology if 'M' not present.
 * J -> JSON output
+* G -> Replace words by glosses
 
 Example:
 ```

--- a/glosser/gismudata.js
+++ b/glosser/gismudata.js
@@ -1813,3 +1813,5 @@ shortDescriptions["zunle"] = "left"
 shortDescriptions["zunti"] = "to interfere"
 shortDescriptions["zutse"] = "to sit"
 shortDescriptions["zvati"] = "at"
+
+module.exports.shortDescriptions = shortDescriptions

--- a/run_camxes.js
+++ b/run_camxes.js
@@ -24,7 +24,7 @@
  *           all the nodes (with the exception of those saved if the 'N' option
  *           is set) are pruned from the tree.
  *    'N' -> Show main node labels
- *    'L' -> Loop
+ *    'L' -> Loop. Second 'L' for specifying the mode in the first word.
  * Example:
  *    -m CTN
  *    This will show terminators, selmaho and main node labels.
@@ -79,9 +79,12 @@ try {
     process.stdout.write(err.toString() + '\n');
     process.exit();
 }
-var mode_loop = among('L', mode);
+var mode_loop = among_count('L', mode);
 if (mode_loop) {
-    process.stdout.write(run_camxes(text, mode, engine) + '\n');
+    mode = mode.replace('L','');
+    if (text != "") {
+        process.stdout.write(run_camxes(text, mode, engine) + '\n');
+    }
     run_camxes_loop(mode, engine);
 } else {
     process.stdout.write(run_camxes(text, mode, engine) + '\n');
@@ -91,6 +94,7 @@ if (mode_loop) {
 // ================================ //
 
 async function run_camxes_loop(mode, engine) {
+    const mode_reset = among_count('L', mode);
     const readline = require('readline')
     const rl = readline.createInterface({
         input: process.stdin,
@@ -100,11 +104,15 @@ async function run_camxes_loop(mode, engine) {
     rl.prompt();
 
     rl.on('line', (line) => {
+        if (mode_reset) {
+            mode = line.substr(0, line.indexOf(' '));
+            line = line.substr(line.indexOf(' ') + 1);
+        }
         ret = run_camxes(line, mode, engine);
         process.stdout.write(run_camxes(line, mode, engine)+ '\n');
         rl.prompt();
     }).on('close', () => {
-        process.stdout.write("co'o\n");
+        process.stdout.write("\nco'o\n");
         process.exit();
     });
 }
@@ -129,11 +137,13 @@ function run_camxes(input, mode, engine) {
     }
 }
 
-// Copied from camxes_postproc
 
-function among(v, s) {
+function among_count(v, s) {
     var i = 0;
-    while (i < s.length) if (s[i++] == v) return true;
-    return false;
+    var ret = 0;
+    while (i < s.length) {
+        if (s[i++] == v) ret = ret + 1;
+    }
+    return ret;
 }
 

--- a/run_camxes.js
+++ b/run_camxes.js
@@ -95,13 +95,13 @@ async function run_camxes_loop(mode, engine) {
     const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,
-        prompt: ''
+        prompt: '> '
     });
     rl.prompt();
 
     rl.on('line', (line) => {
         ret = run_camxes(line, mode, engine);
-        process.stdout.write(run_camxes(line, mode, engine)+ "\n");
+        process.stdout.write(run_camxes(line, mode, engine)+ '\n');
         rl.prompt();
     }).on('close', () => {
         process.stdout.write("co'o\n");

--- a/run_camxes.js
+++ b/run_camxes.js
@@ -24,6 +24,7 @@
  *           all the nodes (with the exception of those saved if the 'N' option
  *           is set) are pruned from the tree.
  *    'N' -> Show main node labels
+ *    'L' -> Loop
  * Example:
  *    -m CTN
  *    This will show terminators, selmaho and main node labels.
@@ -78,8 +79,35 @@ try {
     process.stdout.write(err.toString() + '\n');
     process.exit();
 }
-process.stdout.write(run_camxes(text, mode, engine) + '\n');
-process.exit();
+var mode_loop = among('L', mode);
+if (mode_loop) {
+    process.stdout.write(run_camxes(text, mode, engine) + '\n');
+    run_camxes_loop(mode, engine);
+} else {
+    process.stdout.write(run_camxes(text, mode, engine) + '\n');
+    process.exit();
+}
+
+// ================================ //
+
+async function run_camxes_loop(mode, engine) {
+    const readline = require('readline')
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        prompt: ''
+    });
+    rl.prompt();
+
+    rl.on('line', (line) => {
+        ret = run_camxes(line, mode, engine);
+        process.stdout.write(run_camxes(line, mode, engine)+ "\n");
+        rl.prompt();
+    }).on('close', () => {
+        process.stdout.write("co'o\n");
+        process.exit();
+    });
+}
 
 // ================================ //
 
@@ -99,5 +127,13 @@ function run_camxes(input, mode, engine) {
             result = camxes_postproc.postprocessing(result, mode);
         return result;
     }
+}
+
+// Copied from camxes_postproc
+
+function among(v, s) {
+    var i = 0;
+    while (i < s.length) if (s[i++] == v) return true;
+    return false;
 }
 


### PR DESCRIPTION
These commits mainly implement two new mode options for `run_camxes`:

The mode `G` uses the list of glosses already used for the webpage version to gloss the output.

The mode `L` make `run_camxes` not quit after displaying the parse result of the text passed via command line, but instead enter a loop in which a command prompt is displayed, the user inputs a line of text, the parse result of that text is printed, and the prompt is displayed again etc.

A second `L` makes `run_camxes` expect every input line to begin by a mode string, followed by a space, followed by the actual text. The thusly specified mode will be used for parsing the text in that line instead of the mode passed by command line.

The reason I implemented these was mostly to make it easier/more efficient to use camxes from other programs.