### PR TITLE
Adding support for "je .i".

### DIFF
--- a/camxes-exp.js
+++ b/camxes-exp.js
@@ -1358,7 +1358,7 @@ var camxes = (function() {
     }
 
     function peg$parsetext_1() {
-      var s0, s1, s2, s3, s4, s5, s6;
+      var s0, s1, s2, s3, s4, s5, s6, s7;
 
       var key    = peg$currPos * 805 + 5,
           cached = peg$cache[key];
@@ -1370,60 +1370,117 @@ var camxes = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      s2 = peg$parseI_clause();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsejek();
-        if (s3 === peg$FAILED) {
-          s3 = peg$parsejoik();
+      s2 = peg$currPos;
+      s3 = peg$parsejek();
+      if (s3 === peg$FAILED) {
+        s3 = peg$parsejoik();
+      }
+      if (s3 === peg$FAILED) {
+        s3 = peg$c2;
+      }
+      if (s3 !== peg$FAILED) {
+        s4 = peg$currPos;
+        s5 = peg$parsestag();
+        if (s5 === peg$FAILED) {
+          s5 = peg$c2;
         }
-        if (s3 === peg$FAILED) {
-          s3 = peg$c2;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          s5 = peg$parsestag();
-          if (s5 === peg$FAILED) {
-            s5 = peg$c2;
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parseBO_clause();
-            if (s6 !== peg$FAILED) {
-              s5 = [s5, s6];
-              s4 = s5;
-            } else {
-              peg$currPos = s4;
-              s4 = peg$c0;
-            }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseBO_clause();
+          if (s6 !== peg$FAILED) {
+            s5 = [s5, s6];
+            s4 = s5;
           } else {
             peg$currPos = s4;
             s4 = peg$c0;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$c0;
+        }
+        if (s4 === peg$FAILED) {
+          s4 = peg$c2;
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseI_clause();
+          if (s5 !== peg$FAILED) {
+            s3 = [s3, s4, s5];
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$c0;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$c0;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$c0;
+      }
+      if (s2 === peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = peg$parseI_clause();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsejek();
+          if (s4 === peg$FAILED) {
+            s4 = peg$parsejoik();
           }
           if (s4 === peg$FAILED) {
             s4 = peg$c2;
           }
           if (s4 !== peg$FAILED) {
-            s5 = [];
-            s6 = peg$parsefree();
-            while (s6 !== peg$FAILED) {
-              s5.push(s6);
-              s6 = peg$parsefree();
+            s5 = peg$currPos;
+            s6 = peg$parsestag();
+            if (s6 === peg$FAILED) {
+              s6 = peg$c2;
             }
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parsetext_1();
-              if (s6 === peg$FAILED) {
-                s6 = peg$c2;
-              }
-              if (s6 !== peg$FAILED) {
-                s2 = [s2, s3, s4, s5, s6];
-                s1 = s2;
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseBO_clause();
+              if (s7 !== peg$FAILED) {
+                s6 = [s6, s7];
+                s5 = s6;
               } else {
-                peg$currPos = s1;
-                s1 = peg$c0;
+                peg$currPos = s5;
+                s5 = peg$c0;
               }
             } else {
-              peg$currPos = s1;
-              s1 = peg$c0;
+              peg$currPos = s5;
+              s5 = peg$c0;
             }
+            if (s5 === peg$FAILED) {
+              s5 = peg$c2;
+            }
+            if (s5 !== peg$FAILED) {
+              s3 = [s3, s4, s5];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$c0;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$c0;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$c0;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$parsefree();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parsefree();
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsetext_1();
+          if (s4 === peg$FAILED) {
+            s4 = peg$c2;
+          }
+          if (s4 !== peg$FAILED) {
+            s2 = [s2, s3, s4];
+            s1 = s2;
           } else {
             peg$currPos = s1;
             s1 = peg$c0;
@@ -1846,21 +1903,46 @@ var camxes = (function() {
       if (s2 !== peg$FAILED) {
         s3 = [];
         s4 = peg$currPos;
-        s5 = peg$parseI_clause();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parsejoik_jek();
+        s5 = peg$currPos;
+        s6 = peg$parsejoik_jek();
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parseI_clause();
+          if (s7 !== peg$FAILED) {
+            s6 = [s6, s7];
+            s5 = s6;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$c0;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$c0;
+        }
+        if (s5 === peg$FAILED) {
+          s5 = peg$currPos;
+          s6 = peg$parseI_clause();
           if (s6 !== peg$FAILED) {
-            s7 = peg$parsestatement_2();
-            if (s7 === peg$FAILED) {
-              s7 = peg$c2;
-            }
+            s7 = peg$parsejoik_jek();
             if (s7 !== peg$FAILED) {
-              s5 = [s5, s6, s7];
-              s4 = s5;
+              s6 = [s6, s7];
+              s5 = s6;
             } else {
-              peg$currPos = s4;
-              s4 = peg$c0;
+              peg$currPos = s5;
+              s5 = peg$c0;
             }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$c0;
+          }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parsestatement_2();
+          if (s6 === peg$FAILED) {
+            s6 = peg$c2;
+          }
+          if (s6 !== peg$FAILED) {
+            s5 = [s5, s6];
+            s4 = s5;
           } else {
             peg$currPos = s4;
             s4 = peg$c0;
@@ -1872,21 +1954,46 @@ var camxes = (function() {
         while (s4 !== peg$FAILED) {
           s3.push(s4);
           s4 = peg$currPos;
-          s5 = peg$parseI_clause();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parsejoik_jek();
+          s5 = peg$currPos;
+          s6 = peg$parsejoik_jek();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseI_clause();
+            if (s7 !== peg$FAILED) {
+              s6 = [s6, s7];
+              s5 = s6;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$c0;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$c0;
+          }
+          if (s5 === peg$FAILED) {
+            s5 = peg$currPos;
+            s6 = peg$parseI_clause();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parsestatement_2();
-              if (s7 === peg$FAILED) {
-                s7 = peg$c2;
-              }
+              s7 = peg$parsejoik_jek();
               if (s7 !== peg$FAILED) {
-                s5 = [s5, s6, s7];
-                s4 = s5;
+                s6 = [s6, s7];
+                s5 = s6;
               } else {
-                peg$currPos = s4;
-                s4 = peg$c0;
+                peg$currPos = s5;
+                s5 = peg$c0;
               }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$c0;
+            }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parsestatement_2();
+            if (s6 === peg$FAILED) {
+              s6 = peg$c2;
+            }
+            if (s6 !== peg$FAILED) {
+              s5 = [s5, s6];
+              s4 = s5;
             } else {
               peg$currPos = s4;
               s4 = peg$c0;
@@ -1919,7 +2026,7 @@ var camxes = (function() {
     }
 
     function peg$parsestatement_2() {
-      var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+      var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
       var key    = peg$currPos * 805 + 10,
           cached = peg$cache[key];
@@ -1934,46 +2041,92 @@ var camxes = (function() {
       s2 = peg$parsestatement_3();
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
-        s4 = peg$parseI_clause();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parsejek();
-          if (s5 === peg$FAILED) {
-            s5 = peg$parsejoik();
+        s4 = peg$currPos;
+        s5 = peg$parsejek();
+        if (s5 === peg$FAILED) {
+          s5 = peg$parsejoik();
+        }
+        if (s5 === peg$FAILED) {
+          s5 = peg$c2;
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parsestag();
+          if (s6 === peg$FAILED) {
+            s6 = peg$c2;
           }
-          if (s5 === peg$FAILED) {
-            s5 = peg$c2;
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseBO_clause();
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parseI_clause();
+              if (s8 !== peg$FAILED) {
+                s5 = [s5, s6, s7, s8];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$c0;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$c0;
           }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$c0;
+        }
+        if (s4 === peg$FAILED) {
+          s4 = peg$currPos;
+          s5 = peg$parseI_clause();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parsestag();
+            s6 = peg$parsejek();
+            if (s6 === peg$FAILED) {
+              s6 = peg$parsejoik();
+            }
             if (s6 === peg$FAILED) {
               s6 = peg$c2;
             }
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseBO_clause();
+              s7 = peg$parsestag();
+              if (s7 === peg$FAILED) {
+                s7 = peg$c2;
+              }
               if (s7 !== peg$FAILED) {
-                s8 = [];
-                s9 = peg$parsefree();
-                while (s9 !== peg$FAILED) {
-                  s8.push(s9);
-                  s9 = peg$parsefree();
-                }
+                s8 = peg$parseBO_clause();
                 if (s8 !== peg$FAILED) {
-                  s9 = peg$parsestatement_2();
-                  if (s9 !== peg$FAILED) {
-                    s4 = [s4, s5, s6, s7, s8, s9];
-                    s3 = s4;
-                  } else {
-                    peg$currPos = s3;
-                    s3 = peg$c0;
-                  }
+                  s5 = [s5, s6, s7, s8];
+                  s4 = s5;
                 } else {
-                  peg$currPos = s3;
-                  s3 = peg$c0;
+                  peg$currPos = s4;
+                  s4 = peg$c0;
                 }
               } else {
-                peg$currPos = s3;
-                s3 = peg$c0;
+                peg$currPos = s4;
+                s4 = peg$c0;
               }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$c0;
+          }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = [];
+          s6 = peg$parsefree();
+          while (s6 !== peg$FAILED) {
+            s5.push(s6);
+            s6 = peg$parsefree();
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parsestatement_2();
+            if (s6 !== peg$FAILED) {
+              s4 = [s4, s5, s6];
+              s3 = s4;
             } else {
               peg$currPos = s3;
               s3 = peg$c0;
@@ -2005,44 +2158,90 @@ var camxes = (function() {
         s2 = peg$parsestatement_3();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          s4 = peg$parseI_clause();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parsejek();
-            if (s5 === peg$FAILED) {
-              s5 = peg$parsejoik();
+          s4 = peg$currPos;
+          s5 = peg$parsejek();
+          if (s5 === peg$FAILED) {
+            s5 = peg$parsejoik();
+          }
+          if (s5 === peg$FAILED) {
+            s5 = peg$c2;
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parsestag();
+            if (s6 === peg$FAILED) {
+              s6 = peg$c2;
             }
-            if (s5 === peg$FAILED) {
-              s5 = peg$c2;
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseBO_clause();
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parseI_clause();
+                if (s8 !== peg$FAILED) {
+                  s5 = [s5, s6, s7, s8];
+                  s4 = s5;
+                } else {
+                  peg$currPos = s4;
+                  s4 = peg$c0;
+                }
+              } else {
+                peg$currPos = s4;
+                s4 = peg$c0;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
             }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$c0;
+          }
+          if (s4 === peg$FAILED) {
+            s4 = peg$currPos;
+            s5 = peg$parseI_clause();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parsestag();
+              s6 = peg$parsejek();
+              if (s6 === peg$FAILED) {
+                s6 = peg$parsejoik();
+              }
               if (s6 === peg$FAILED) {
                 s6 = peg$c2;
               }
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseBO_clause();
+                s7 = peg$parsestag();
+                if (s7 === peg$FAILED) {
+                  s7 = peg$c2;
+                }
                 if (s7 !== peg$FAILED) {
-                  s8 = [];
-                  s9 = peg$parsefree();
-                  while (s9 !== peg$FAILED) {
-                    s8.push(s9);
-                    s9 = peg$parsefree();
-                  }
+                  s8 = peg$parseBO_clause();
                   if (s8 !== peg$FAILED) {
-                    s4 = [s4, s5, s6, s7, s8];
-                    s3 = s4;
+                    s5 = [s5, s6, s7, s8];
+                    s4 = s5;
                   } else {
-                    peg$currPos = s3;
-                    s3 = peg$c0;
+                    peg$currPos = s4;
+                    s4 = peg$c0;
                   }
                 } else {
-                  peg$currPos = s3;
-                  s3 = peg$c0;
+                  peg$currPos = s4;
+                  s4 = peg$c0;
                 }
               } else {
-                peg$currPos = s3;
-                s3 = peg$c0;
+                peg$currPos = s4;
+                s4 = peg$c0;
               }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$c0;
+            }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parsefree();
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
+              s6 = peg$parsefree();
+            }
+            if (s5 !== peg$FAILED) {
+              s4 = [s4, s5];
+              s3 = s4;
             } else {
               peg$currPos = s3;
               s3 = peg$c0;

--- a/camxes-exp.peg
+++ b/camxes-exp.peg
@@ -55,7 +55,7 @@ faho_clause <- (FAhO_clause dot_star)?
 # Please note that the "text_1" item in the text_1 production does
 # *not* match the BNF. This is due to a bug in the BNF.  The change
 # here was made to match grammar.300
-text_1 <- I_clause (jek / joik)? (stag? BO_clause)? free* text_1? / NIhO_clause+ free* su_clause* paragraphs? / paragraphs
+text_1 <- (((jek / joik)? (stag? BO_clause)? I_clause) / (I_clause (jek / joik)? (stag? BO_clause)?)) free* text_1? / NIhO_clause+ free* su_clause* paragraphs? / paragraphs
 
 paragraphs <- paragraph? (NIhO_clause+ free* su_clause* paragraphs)?
 
@@ -63,9 +63,9 @@ paragraph <- (statement / fragment) (I_clause !jek !joik !joik_jek free* (statem
 
 statement <- statement_1 / prenex statement
 
-statement_1 <- statement_2 (I_clause joik_jek statement_2?)*
+statement_1 <- statement_2 (((joik_jek I_clause) / (I_clause joik_jek)) statement_2?)*
 
-statement_2 <- statement_3 (I_clause (jek / joik)? stag? BO_clause free* statement_2)? / statement_3 (I_clause (jek / joik)? stag? BO_clause free*)?
+statement_2 <- statement_3 ((((jek / joik)? stag? BO_clause I_clause) / (I_clause (jek / joik)? stag? BO_clause)) free* statement_2)? / statement_3 ((((jek / joik)? stag? BO_clause I_clause) / (I_clause (jek / joik)? stag? BO_clause)) free*)?
 
 statement_3 <- sentence / tag? TUhE_clause free* text_1 TUhU_elidible free*
 

--- a/camxes-exp.pegjs
+++ b/camxes-exp.pegjs
@@ -184,7 +184,7 @@ faho_clause = expr:((FAhO_clause dot_star)?) {return _node("faho_clause", expr);
 // Please note that the "text_1" item in the text_1 production does
 // *not* match the BNF. This is due to a bug in the BNF.  The change
 // here was made to match grammar.300
-text_1 = expr:(I_clause (jek / joik)? (stag? BO_clause)? free* text_1? / NIhO_clause+ free* su_clause* paragraphs? / paragraphs) {return _node("text_1", expr);}
+text_1 = expr:((((jek / joik)? (stag? BO_clause)? I_clause) / (I_clause (jek / joik)? (stag? BO_clause)?)) free* text_1? / NIhO_clause+ free* su_clause* paragraphs? / paragraphs) {return _node("text_1", expr);}
 
 paragraphs = expr:(paragraph? (NIhO_clause+ free* su_clause* paragraphs)?) {return _node("paragraphs", expr);}
 
@@ -192,9 +192,9 @@ paragraph = expr:((statement / fragment) (I_clause !jek !joik !joik_jek free* (s
 
 statement = expr:(statement_1 / prenex statement) {return _node("statement", expr);}
 
-statement_1 = expr:(statement_2 (I_clause joik_jek statement_2?)*) {return _node("statement_1", expr);}
+statement_1 = expr:(statement_2 (((joik_jek I_clause) / (I_clause joik_jek)) statement_2?)*) {return _node("statement_1", expr);}
 
-statement_2 = expr:(statement_3 (I_clause (jek / joik)? stag? BO_clause free* statement_2)? / statement_3 (I_clause (jek / joik)? stag? BO_clause free*)?) {return _node("statement_2", expr);}
+statement_2 = expr:(statement_3 ((((jek / joik)? stag? BO_clause I_clause) / (I_clause (jek / joik)? stag? BO_clause)) free* statement_2)? / statement_3 ((((jek / joik)? stag? BO_clause I_clause) / (I_clause (jek / joik)? stag? BO_clause)) free*)?) {return _node("statement_2", expr);}
 
 statement_3 = expr:(sentence / tag? TUhE_clause free* text_1 TUhU_elidible free*) {return _node("statement_3", expr);}
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "A  syntactical and not yet semantical parser for the Lojban language",
   "dependencies": {
-    "pegjs": "^0.8.0"
+    "pegjs": ">=0.7.0 <=0.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Camxes-beta supports the use of both "je .i" and ".i je," but camxes-exp does not, so I would like to correct this.