### PR TITLE
Added {zu'ai} to camxes-exp.

### DIFF
--- a/camxes-exp.js
+++ b/camxes-exp.js
@@ -50321,15 +50321,15 @@ var camxes = (function() {
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
-        s4 = peg$parsen();
+        s4 = peg$parsez();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parsea();
+          s5 = peg$parseu();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parseu();
+            s6 = peg$parseh();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseh();
+              s7 = peg$parsea();
               if (s7 !== peg$FAILED) {
-                s8 = peg$parseo();
+                s8 = peg$parsei();
                 if (s8 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7, s8];
                   s3 = s4;
@@ -50355,16 +50355,22 @@ var camxes = (function() {
         }
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
-          s4 = peg$parsed();
+          s4 = peg$parsen();
           if (s4 !== peg$FAILED) {
             s5 = peg$parsea();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parseh();
+              s6 = peg$parseu();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseu();
+                s7 = peg$parseh();
                 if (s7 !== peg$FAILED) {
-                  s4 = [s4, s5, s6, s7];
-                  s3 = s4;
+                  s8 = peg$parseo();
+                  if (s8 !== peg$FAILED) {
+                    s4 = [s4, s5, s6, s7, s8];
+                    s3 = s4;
+                  } else {
+                    peg$currPos = s3;
+                    s3 = peg$c0;
+                  }
                 } else {
                   peg$currPos = s3;
                   s3 = peg$c0;
@@ -50389,7 +50395,7 @@ var camxes = (function() {
               if (s5 !== peg$FAILED) {
                 s6 = peg$parseh();
                 if (s6 !== peg$FAILED) {
-                  s7 = peg$parsee();
+                  s7 = peg$parseu();
                   if (s7 !== peg$FAILED) {
                     s4 = [s4, s5, s6, s7];
                     s3 = s4;
@@ -50413,11 +50419,11 @@ var camxes = (function() {
               s3 = peg$currPos;
               s4 = peg$parsed();
               if (s4 !== peg$FAILED) {
-                s5 = peg$parsei();
+                s5 = peg$parsea();
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parseh();
                   if (s6 !== peg$FAILED) {
-                    s7 = peg$parseu();
+                    s7 = peg$parsee();
                     if (s7 !== peg$FAILED) {
                       s4 = [s4, s5, s6, s7];
                       s3 = s4;
@@ -50445,7 +50451,7 @@ var camxes = (function() {
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parseh();
                     if (s6 !== peg$FAILED) {
-                      s7 = peg$parsee();
+                      s7 = peg$parseu();
                       if (s7 !== peg$FAILED) {
                         s4 = [s4, s5, s6, s7];
                         s3 = s4;
@@ -50469,11 +50475,11 @@ var camxes = (function() {
                   s3 = peg$currPos;
                   s4 = peg$parsed();
                   if (s4 !== peg$FAILED) {
-                    s5 = peg$parsee();
+                    s5 = peg$parsei();
                     if (s5 !== peg$FAILED) {
                       s6 = peg$parseh();
                       if (s6 !== peg$FAILED) {
-                        s7 = peg$parseu();
+                        s7 = peg$parsee();
                         if (s7 !== peg$FAILED) {
                           s4 = [s4, s5, s6, s7];
                           s3 = s4;
@@ -50501,7 +50507,7 @@ var camxes = (function() {
                       if (s5 !== peg$FAILED) {
                         s6 = peg$parseh();
                         if (s6 !== peg$FAILED) {
-                          s7 = peg$parsee();
+                          s7 = peg$parseu();
                           if (s7 !== peg$FAILED) {
                             s4 = [s4, s5, s6, s7];
                             s3 = s4;
@@ -50527,10 +50533,16 @@ var camxes = (function() {
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsee();
                         if (s5 !== peg$FAILED) {
-                          s6 = peg$parsei();
+                          s6 = peg$parseh();
                           if (s6 !== peg$FAILED) {
-                            s4 = [s4, s5, s6];
-                            s3 = s4;
+                            s7 = peg$parsee();
+                            if (s7 !== peg$FAILED) {
+                              s4 = [s4, s5, s6, s7];
+                              s3 = s4;
+                            } else {
+                              peg$currPos = s3;
+                              s3 = peg$c0;
+                            }
                           } else {
                             peg$currPos = s3;
                             s3 = peg$c0;
@@ -50547,18 +50559,12 @@ var camxes = (function() {
                         s3 = peg$currPos;
                         s4 = peg$parsed();
                         if (s4 !== peg$FAILED) {
-                          s5 = peg$parseo();
+                          s5 = peg$parsee();
                           if (s5 !== peg$FAILED) {
-                            s6 = peg$parseh();
+                            s6 = peg$parsei();
                             if (s6 !== peg$FAILED) {
-                              s7 = peg$parsei();
-                              if (s7 !== peg$FAILED) {
-                                s4 = [s4, s5, s6, s7];
-                                s3 = s4;
-                              } else {
-                                peg$currPos = s3;
-                                s3 = peg$c0;
-                              }
+                              s4 = [s4, s5, s6];
+                              s3 = s4;
                             } else {
                               peg$currPos = s3;
                               s3 = peg$c0;
@@ -50573,13 +50579,13 @@ var camxes = (function() {
                         }
                         if (s3 === peg$FAILED) {
                           s3 = peg$currPos;
-                          s4 = peg$parsem();
+                          s4 = peg$parsed();
                           if (s4 !== peg$FAILED) {
-                            s5 = peg$parsei();
+                            s5 = peg$parseo();
                             if (s5 !== peg$FAILED) {
                               s6 = peg$parseh();
                               if (s6 !== peg$FAILED) {
-                                s7 = peg$parseo();
+                                s7 = peg$parsei();
                                 if (s7 !== peg$FAILED) {
                                   s4 = [s4, s5, s6, s7];
                                   s3 = s4;
@@ -50607,16 +50613,10 @@ var camxes = (function() {
                               if (s5 !== peg$FAILED) {
                                 s6 = peg$parseh();
                                 if (s6 !== peg$FAILED) {
-                                  s7 = peg$parsea();
+                                  s7 = peg$parseo();
                                   if (s7 !== peg$FAILED) {
-                                    s8 = peg$parsei();
-                                    if (s8 !== peg$FAILED) {
-                                      s4 = [s4, s5, s6, s7, s8];
-                                      s3 = s4;
-                                    } else {
-                                      peg$currPos = s3;
-                                      s3 = peg$c0;
-                                    }
+                                    s4 = [s4, s5, s6, s7];
+                                    s3 = s4;
                                   } else {
                                     peg$currPos = s3;
                                     s3 = peg$c0;
@@ -50637,14 +50637,20 @@ var camxes = (function() {
                               s3 = peg$currPos;
                               s4 = peg$parsem();
                               if (s4 !== peg$FAILED) {
-                                s5 = peg$parsea();
+                                s5 = peg$parsei();
                                 if (s5 !== peg$FAILED) {
                                   s6 = peg$parseh();
                                   if (s6 !== peg$FAILED) {
                                     s7 = peg$parsea();
                                     if (s7 !== peg$FAILED) {
-                                      s4 = [s4, s5, s6, s7];
-                                      s3 = s4;
+                                      s8 = peg$parsei();
+                                      if (s8 !== peg$FAILED) {
+                                        s4 = [s4, s5, s6, s7, s8];
+                                        s3 = s4;
+                                      } else {
+                                        peg$currPos = s3;
+                                        s3 = peg$c0;
+                                      }
                                     } else {
                                       peg$currPos = s3;
                                       s3 = peg$c0;
@@ -50665,7 +50671,7 @@ var camxes = (function() {
                                 s3 = peg$currPos;
                                 s4 = peg$parsem();
                                 if (s4 !== peg$FAILED) {
-                                  s5 = peg$parsei();
+                                  s5 = peg$parsea();
                                   if (s5 !== peg$FAILED) {
                                     s6 = peg$parseh();
                                     if (s6 !== peg$FAILED) {
@@ -50691,13 +50697,13 @@ var camxes = (function() {
                                 }
                                 if (s3 === peg$FAILED) {
                                   s3 = peg$currPos;
-                                  s4 = peg$parsed();
+                                  s4 = peg$parsem();
                                   if (s4 !== peg$FAILED) {
-                                    s5 = peg$parseo();
+                                    s5 = peg$parsei();
                                     if (s5 !== peg$FAILED) {
                                       s6 = peg$parseh();
                                       if (s6 !== peg$FAILED) {
-                                        s7 = peg$parseo();
+                                        s7 = peg$parsea();
                                         if (s7 !== peg$FAILED) {
                                           s4 = [s4, s5, s6, s7];
                                           s3 = s4;
@@ -50719,13 +50725,13 @@ var camxes = (function() {
                                   }
                                   if (s3 === peg$FAILED) {
                                     s3 = peg$currPos;
-                                    s4 = peg$parsek();
+                                    s4 = peg$parsed();
                                     if (s4 !== peg$FAILED) {
                                       s5 = peg$parseo();
                                       if (s5 !== peg$FAILED) {
                                         s6 = peg$parseh();
                                         if (s6 !== peg$FAILED) {
-                                          s7 = peg$parsea();
+                                          s7 = peg$parseo();
                                           if (s7 !== peg$FAILED) {
                                             s4 = [s4, s5, s6, s7];
                                             s3 = s4;
@@ -50747,13 +50753,13 @@ var camxes = (function() {
                                     }
                                     if (s3 === peg$FAILED) {
                                       s3 = peg$currPos;
-                                      s4 = peg$parsef();
+                                      s4 = peg$parsek();
                                       if (s4 !== peg$FAILED) {
                                         s5 = peg$parseo();
                                         if (s5 !== peg$FAILED) {
                                           s6 = peg$parseh();
                                           if (s6 !== peg$FAILED) {
-                                            s7 = peg$parseu();
+                                            s7 = peg$parsea();
                                             if (s7 !== peg$FAILED) {
                                               s4 = [s4, s5, s6, s7];
                                               s3 = s4;
@@ -50775,13 +50781,13 @@ var camxes = (function() {
                                       }
                                       if (s3 === peg$FAILED) {
                                         s3 = peg$currPos;
-                                        s4 = peg$parsek();
+                                        s4 = peg$parsef();
                                         if (s4 !== peg$FAILED) {
                                           s5 = peg$parseo();
                                           if (s5 !== peg$FAILED) {
                                             s6 = peg$parseh();
                                             if (s6 !== peg$FAILED) {
-                                              s7 = peg$parsee();
+                                              s7 = peg$parseu();
                                               if (s7 !== peg$FAILED) {
                                                 s4 = [s4, s5, s6, s7];
                                                 s3 = s4;
@@ -50809,7 +50815,7 @@ var camxes = (function() {
                                             if (s5 !== peg$FAILED) {
                                               s6 = peg$parseh();
                                               if (s6 !== peg$FAILED) {
-                                                s7 = peg$parsei();
+                                                s7 = peg$parsee();
                                                 if (s7 !== peg$FAILED) {
                                                   s4 = [s4, s5, s6, s7];
                                                   s3 = s4;
@@ -50837,7 +50843,7 @@ var camxes = (function() {
                                               if (s5 !== peg$FAILED) {
                                                 s6 = peg$parseh();
                                                 if (s6 !== peg$FAILED) {
-                                                  s7 = peg$parseo();
+                                                  s7 = peg$parsei();
                                                   if (s7 !== peg$FAILED) {
                                                     s4 = [s4, s5, s6, s7];
                                                     s3 = s4;
@@ -50865,7 +50871,7 @@ var camxes = (function() {
                                                 if (s5 !== peg$FAILED) {
                                                   s6 = peg$parseh();
                                                   if (s6 !== peg$FAILED) {
-                                                    s7 = peg$parseu();
+                                                    s7 = peg$parseo();
                                                     if (s7 !== peg$FAILED) {
                                                       s4 = [s4, s5, s6, s7];
                                                       s3 = s4;
@@ -50887,13 +50893,13 @@ var camxes = (function() {
                                               }
                                               if (s3 === peg$FAILED) {
                                                 s3 = peg$currPos;
-                                                s4 = peg$parsef();
+                                                s4 = peg$parsek();
                                                 if (s4 !== peg$FAILED) {
                                                   s5 = peg$parseo();
                                                   if (s5 !== peg$FAILED) {
                                                     s6 = peg$parseh();
                                                     if (s6 !== peg$FAILED) {
-                                                      s7 = peg$parsea();
+                                                      s7 = peg$parseu();
                                                       if (s7 !== peg$FAILED) {
                                                         s4 = [s4, s5, s6, s7];
                                                         s3 = s4;
@@ -50921,7 +50927,7 @@ var camxes = (function() {
                                                     if (s5 !== peg$FAILED) {
                                                       s6 = peg$parseh();
                                                       if (s6 !== peg$FAILED) {
-                                                        s7 = peg$parsee();
+                                                        s7 = peg$parsea();
                                                         if (s7 !== peg$FAILED) {
                                                           s4 = [s4, s5, s6, s7];
                                                           s3 = s4;
@@ -50949,7 +50955,7 @@ var camxes = (function() {
                                                       if (s5 !== peg$FAILED) {
                                                         s6 = peg$parseh();
                                                         if (s6 !== peg$FAILED) {
-                                                          s7 = peg$parsei();
+                                                          s7 = peg$parsee();
                                                           if (s7 !== peg$FAILED) {
                                                             s4 = [s4, s5, s6, s7];
                                                             s3 = s4;
@@ -50977,7 +50983,7 @@ var camxes = (function() {
                                                         if (s5 !== peg$FAILED) {
                                                           s6 = peg$parseh();
                                                           if (s6 !== peg$FAILED) {
-                                                            s7 = peg$parseo();
+                                                            s7 = peg$parsei();
                                                             if (s7 !== peg$FAILED) {
                                                               s4 = [s4, s5, s6, s7];
                                                               s3 = s4;
@@ -50999,13 +51005,13 @@ var camxes = (function() {
                                                       }
                                                       if (s3 === peg$FAILED) {
                                                         s3 = peg$currPos;
-                                                        s4 = peg$parsev();
+                                                        s4 = peg$parsef();
                                                         if (s4 !== peg$FAILED) {
                                                           s5 = peg$parseo();
                                                           if (s5 !== peg$FAILED) {
                                                             s6 = peg$parseh();
                                                             if (s6 !== peg$FAILED) {
-                                                              s7 = peg$parsea();
+                                                              s7 = peg$parseo();
                                                               if (s7 !== peg$FAILED) {
                                                                 s4 = [s4, s5, s6, s7];
                                                                 s3 = s4;
@@ -51033,7 +51039,7 @@ var camxes = (function() {
                                                             if (s5 !== peg$FAILED) {
                                                               s6 = peg$parseh();
                                                               if (s6 !== peg$FAILED) {
-                                                                s7 = peg$parsee();
+                                                                s7 = peg$parsea();
                                                                 if (s7 !== peg$FAILED) {
                                                                   s4 = [s4, s5, s6, s7];
                                                                   s3 = s4;
@@ -51061,7 +51067,7 @@ var camxes = (function() {
                                                               if (s5 !== peg$FAILED) {
                                                                 s6 = peg$parseh();
                                                                 if (s6 !== peg$FAILED) {
-                                                                  s7 = peg$parsei();
+                                                                  s7 = peg$parsee();
                                                                   if (s7 !== peg$FAILED) {
                                                                     s4 = [s4, s5, s6, s7];
                                                                     s3 = s4;
@@ -51089,7 +51095,7 @@ var camxes = (function() {
                                                                 if (s5 !== peg$FAILED) {
                                                                   s6 = peg$parseh();
                                                                   if (s6 !== peg$FAILED) {
-                                                                    s7 = peg$parseo();
+                                                                    s7 = peg$parsei();
                                                                     if (s7 !== peg$FAILED) {
                                                                       s4 = [s4, s5, s6, s7];
                                                                       s3 = s4;
@@ -51117,7 +51123,7 @@ var camxes = (function() {
                                                                   if (s5 !== peg$FAILED) {
                                                                     s6 = peg$parseh();
                                                                     if (s6 !== peg$FAILED) {
-                                                                      s7 = peg$parseu();
+                                                                      s7 = peg$parseo();
                                                                       if (s7 !== peg$FAILED) {
                                                                         s4 = [s4, s5, s6, s7];
                                                                         s3 = s4;
@@ -51139,12 +51145,24 @@ var camxes = (function() {
                                                                 }
                                                                 if (s3 === peg$FAILED) {
                                                                   s3 = peg$currPos;
-                                                                  s4 = peg$parser();
+                                                                  s4 = peg$parsev();
                                                                   if (s4 !== peg$FAILED) {
-                                                                    s5 = peg$parseu();
+                                                                    s5 = peg$parseo();
                                                                     if (s5 !== peg$FAILED) {
-                                                                      s4 = [s4, s5];
-                                                                      s3 = s4;
+                                                                      s6 = peg$parseh();
+                                                                      if (s6 !== peg$FAILED) {
+                                                                        s7 = peg$parseu();
+                                                                        if (s7 !== peg$FAILED) {
+                                                                          s4 = [s4, s5, s6, s7];
+                                                                          s3 = s4;
+                                                                        } else {
+                                                                          peg$currPos = s3;
+                                                                          s3 = peg$c0;
+                                                                        }
+                                                                      } else {
+                                                                        peg$currPos = s3;
+                                                                        s3 = peg$c0;
+                                                                      }
                                                                     } else {
                                                                       peg$currPos = s3;
                                                                       s3 = peg$c0;
@@ -51157,7 +51175,7 @@ var camxes = (function() {
                                                                     s3 = peg$currPos;
                                                                     s4 = peg$parser();
                                                                     if (s4 !== peg$FAILED) {
-                                                                      s5 = peg$parsei();
+                                                                      s5 = peg$parseu();
                                                                       if (s5 !== peg$FAILED) {
                                                                         s4 = [s4, s5];
                                                                         s3 = s4;
@@ -51173,7 +51191,7 @@ var camxes = (function() {
                                                                       s3 = peg$currPos;
                                                                       s4 = peg$parser();
                                                                       if (s4 !== peg$FAILED) {
-                                                                        s5 = peg$parsea();
+                                                                        s5 = peg$parsei();
                                                                         if (s5 !== peg$FAILED) {
                                                                           s4 = [s4, s5];
                                                                           s3 = s4;
@@ -51187,7 +51205,7 @@ var camxes = (function() {
                                                                       }
                                                                       if (s3 === peg$FAILED) {
                                                                         s3 = peg$currPos;
-                                                                        s4 = peg$parset();
+                                                                        s4 = peg$parser();
                                                                         if (s4 !== peg$FAILED) {
                                                                           s5 = peg$parsea();
                                                                           if (s5 !== peg$FAILED) {
@@ -51205,7 +51223,7 @@ var camxes = (function() {
                                                                           s3 = peg$currPos;
                                                                           s4 = peg$parset();
                                                                           if (s4 !== peg$FAILED) {
-                                                                            s5 = peg$parseu();
+                                                                            s5 = peg$parsea();
                                                                             if (s5 !== peg$FAILED) {
                                                                               s4 = [s4, s5];
                                                                               s3 = s4;
@@ -51221,7 +51239,7 @@ var camxes = (function() {
                                                                             s3 = peg$currPos;
                                                                             s4 = peg$parset();
                                                                             if (s4 !== peg$FAILED) {
-                                                                              s5 = peg$parsei();
+                                                                              s5 = peg$parseu();
                                                                               if (s5 !== peg$FAILED) {
                                                                                 s4 = [s4, s5];
                                                                                 s3 = s4;
@@ -51235,24 +51253,12 @@ var camxes = (function() {
                                                                             }
                                                                             if (s3 === peg$FAILED) {
                                                                               s3 = peg$currPos;
-                                                                              s4 = peg$parsez();
+                                                                              s4 = peg$parset();
                                                                               if (s4 !== peg$FAILED) {
                                                                                 s5 = peg$parsei();
                                                                                 if (s5 !== peg$FAILED) {
-                                                                                  s6 = peg$parseh();
-                                                                                  if (s6 !== peg$FAILED) {
-                                                                                    s7 = peg$parseo();
-                                                                                    if (s7 !== peg$FAILED) {
-                                                                                      s4 = [s4, s5, s6, s7];
-                                                                                      s3 = s4;
-                                                                                    } else {
-                                                                                      peg$currPos = s3;
-                                                                                      s3 = peg$c0;
-                                                                                    }
-                                                                                  } else {
-                                                                                    peg$currPos = s3;
-                                                                                    s3 = peg$c0;
-                                                                                  }
+                                                                                  s4 = [s4, s5];
+                                                                                  s3 = s4;
                                                                                 } else {
                                                                                   peg$currPos = s3;
                                                                                   s3 = peg$c0;
@@ -51263,13 +51269,13 @@ var camxes = (function() {
                                                                               }
                                                                               if (s3 === peg$FAILED) {
                                                                                 s3 = peg$currPos;
-                                                                                s4 = peg$parsek();
+                                                                                s4 = peg$parsez();
                                                                                 if (s4 !== peg$FAILED) {
-                                                                                  s5 = peg$parsee();
+                                                                                  s5 = peg$parsei();
                                                                                   if (s5 !== peg$FAILED) {
                                                                                     s6 = peg$parseh();
                                                                                     if (s6 !== peg$FAILED) {
-                                                                                      s7 = peg$parsea();
+                                                                                      s7 = peg$parseo();
                                                                                       if (s7 !== peg$FAILED) {
                                                                                         s4 = [s4, s5, s6, s7];
                                                                                         s3 = s4;
@@ -51291,36 +51297,16 @@ var camxes = (function() {
                                                                                 }
                                                                                 if (s3 === peg$FAILED) {
                                                                                   s3 = peg$currPos;
-                                                                                  s4 = peg$parsem();
+                                                                                  s4 = peg$parsek();
                                                                                   if (s4 !== peg$FAILED) {
-                                                                                    s5 = peg$parsea();
+                                                                                    s5 = peg$parsee();
                                                                                     if (s5 !== peg$FAILED) {
-                                                                                      s4 = [s4, s5];
-                                                                                      s3 = s4;
-                                                                                    } else {
-                                                                                      peg$currPos = s3;
-                                                                                      s3 = peg$c0;
-                                                                                    }
-                                                                                  } else {
-                                                                                    peg$currPos = s3;
-                                                                                    s3 = peg$c0;
-                                                                                  }
-                                                                                  if (s3 === peg$FAILED) {
-                                                                                    s3 = peg$currPos;
-                                                                                    s4 = peg$parsez();
-                                                                                    if (s4 !== peg$FAILED) {
-                                                                                      s5 = peg$parseu();
-                                                                                      if (s5 !== peg$FAILED) {
-                                                                                        s6 = peg$parseh();
-                                                                                        if (s6 !== peg$FAILED) {
-                                                                                          s7 = peg$parsei();
-                                                                                          if (s7 !== peg$FAILED) {
-                                                                                            s4 = [s4, s5, s6, s7];
-                                                                                            s3 = s4;
-                                                                                          } else {
-                                                                                            peg$currPos = s3;
-                                                                                            s3 = peg$c0;
-                                                                                          }
+                                                                                      s6 = peg$parseh();
+                                                                                      if (s6 !== peg$FAILED) {
+                                                                                        s7 = peg$parsea();
+                                                                                        if (s7 !== peg$FAILED) {
+                                                                                          s4 = [s4, s5, s6, s7];
+                                                                                          s3 = s4;
                                                                                         } else {
                                                                                           peg$currPos = s3;
                                                                                           s3 = peg$c0;
@@ -51333,15 +51319,35 @@ var camxes = (function() {
                                                                                       peg$currPos = s3;
                                                                                       s3 = peg$c0;
                                                                                     }
+                                                                                  } else {
+                                                                                    peg$currPos = s3;
+                                                                                    s3 = peg$c0;
+                                                                                  }
+                                                                                  if (s3 === peg$FAILED) {
+                                                                                    s3 = peg$currPos;
+                                                                                    s4 = peg$parsem();
+                                                                                    if (s4 !== peg$FAILED) {
+                                                                                      s5 = peg$parsea();
+                                                                                      if (s5 !== peg$FAILED) {
+                                                                                        s4 = [s4, s5];
+                                                                                        s3 = s4;
+                                                                                      } else {
+                                                                                        peg$currPos = s3;
+                                                                                        s3 = peg$c0;
+                                                                                      }
+                                                                                    } else {
+                                                                                      peg$currPos = s3;
+                                                                                      s3 = peg$c0;
+                                                                                    }
                                                                                     if (s3 === peg$FAILED) {
                                                                                       s3 = peg$currPos;
                                                                                       s4 = peg$parsez();
                                                                                       if (s4 !== peg$FAILED) {
-                                                                                        s5 = peg$parseo();
+                                                                                        s5 = peg$parseu();
                                                                                         if (s5 !== peg$FAILED) {
                                                                                           s6 = peg$parseh();
                                                                                           if (s6 !== peg$FAILED) {
-                                                                                            s7 = peg$parsee();
+                                                                                            s7 = peg$parsei();
                                                                                             if (s7 !== peg$FAILED) {
                                                                                               s4 = [s4, s5, s6, s7];
                                                                                               s3 = s4;
@@ -51363,13 +51369,13 @@ var camxes = (function() {
                                                                                       }
                                                                                       if (s3 === peg$FAILED) {
                                                                                         s3 = peg$currPos;
-                                                                                        s4 = peg$parsec();
+                                                                                        s4 = peg$parsez();
                                                                                         if (s4 !== peg$FAILED) {
-                                                                                          s5 = peg$parsee();
+                                                                                          s5 = peg$parseo();
                                                                                           if (s5 !== peg$FAILED) {
                                                                                             s6 = peg$parseh();
                                                                                             if (s6 !== peg$FAILED) {
-                                                                                              s7 = peg$parseu();
+                                                                                              s7 = peg$parsee();
                                                                                               if (s7 !== peg$FAILED) {
                                                                                                 s4 = [s4, s5, s6, s7];
                                                                                                 s3 = s4;
@@ -51391,12 +51397,24 @@ var camxes = (function() {
                                                                                         }
                                                                                         if (s3 === peg$FAILED) {
                                                                                           s3 = peg$currPos;
-                                                                                          s4 = peg$parsed();
+                                                                                          s4 = peg$parsec();
                                                                                           if (s4 !== peg$FAILED) {
-                                                                                            s5 = peg$parsea();
+                                                                                            s5 = peg$parsee();
                                                                                             if (s5 !== peg$FAILED) {
-                                                                                              s4 = [s4, s5];
-                                                                                              s3 = s4;
+                                                                                              s6 = peg$parseh();
+                                                                                              if (s6 !== peg$FAILED) {
+                                                                                                s7 = peg$parseu();
+                                                                                                if (s7 !== peg$FAILED) {
+                                                                                                  s4 = [s4, s5, s6, s7];
+                                                                                                  s3 = s4;
+                                                                                                } else {
+                                                                                                  peg$currPos = s3;
+                                                                                                  s3 = peg$c0;
+                                                                                                }
+                                                                                              } else {
+                                                                                                peg$currPos = s3;
+                                                                                                s3 = peg$c0;
+                                                                                              }
                                                                                             } else {
                                                                                               peg$currPos = s3;
                                                                                               s3 = peg$c0;
@@ -51409,7 +51427,7 @@ var camxes = (function() {
                                                                                             s3 = peg$currPos;
                                                                                             s4 = peg$parsed();
                                                                                             if (s4 !== peg$FAILED) {
-                                                                                              s5 = peg$parsee();
+                                                                                              s5 = peg$parsea();
                                                                                               if (s5 !== peg$FAILED) {
                                                                                                 s4 = [s4, s5];
                                                                                                 s3 = s4;
@@ -51425,7 +51443,7 @@ var camxes = (function() {
                                                                                               s3 = peg$currPos;
                                                                                               s4 = peg$parsed();
                                                                                               if (s4 !== peg$FAILED) {
-                                                                                                s5 = peg$parsei();
+                                                                                                s5 = peg$parsee();
                                                                                                 if (s5 !== peg$FAILED) {
                                                                                                   s4 = [s4, s5];
                                                                                                   s3 = s4;
@@ -51439,9 +51457,9 @@ var camxes = (function() {
                                                                                               }
                                                                                               if (s3 === peg$FAILED) {
                                                                                                 s3 = peg$currPos;
-                                                                                                s4 = peg$parsek();
+                                                                                                s4 = peg$parsed();
                                                                                                 if (s4 !== peg$FAILED) {
-                                                                                                  s5 = peg$parseo();
+                                                                                                  s5 = peg$parsei();
                                                                                                   if (s5 !== peg$FAILED) {
                                                                                                     s4 = [s4, s5];
                                                                                                     s3 = s4;
@@ -51455,9 +51473,9 @@ var camxes = (function() {
                                                                                                 }
                                                                                                 if (s3 === peg$FAILED) {
                                                                                                   s3 = peg$currPos;
-                                                                                                  s4 = peg$parsem();
+                                                                                                  s4 = peg$parsek();
                                                                                                   if (s4 !== peg$FAILED) {
-                                                                                                    s5 = peg$parsei();
+                                                                                                    s5 = peg$parseo();
                                                                                                     if (s5 !== peg$FAILED) {
                                                                                                       s4 = [s4, s5];
                                                                                                       s3 = s4;
@@ -51471,9 +51489,9 @@ var camxes = (function() {
                                                                                                   }
                                                                                                   if (s3 === peg$FAILED) {
                                                                                                     s3 = peg$currPos;
-                                                                                                    s4 = peg$parsed();
+                                                                                                    s4 = peg$parsem();
                                                                                                     if (s4 !== peg$FAILED) {
-                                                                                                      s5 = peg$parseo();
+                                                                                                      s5 = peg$parsei();
                                                                                                       if (s5 !== peg$FAILED) {
                                                                                                         s4 = [s4, s5];
                                                                                                         s3 = s4;
@@ -51487,14 +51505,34 @@ var camxes = (function() {
                                                                                                     }
                                                                                                     if (s3 === peg$FAILED) {
                                                                                                       s3 = peg$currPos;
-                                                                                                      s4 = peg$parsex();
+                                                                                                      s4 = peg$parsed();
                                                                                                       if (s4 !== peg$FAILED) {
-                                                                                                        s5 = peg$parsea();
+                                                                                                        s5 = peg$parseo();
                                                                                                         if (s5 !== peg$FAILED) {
-                                                                                                          s6 = peg$parsei();
-                                                                                                          if (s6 !== peg$FAILED) {
-                                                                                                            s4 = [s4, s5, s6];
-                                                                                                            s3 = s4;
+                                                                                                          s4 = [s4, s5];
+                                                                                                          s3 = s4;
+                                                                                                        } else {
+                                                                                                          peg$currPos = s3;
+                                                                                                          s3 = peg$c0;
+                                                                                                        }
+                                                                                                      } else {
+                                                                                                        peg$currPos = s3;
+                                                                                                        s3 = peg$c0;
+                                                                                                      }
+                                                                                                      if (s3 === peg$FAILED) {
+                                                                                                        s3 = peg$currPos;
+                                                                                                        s4 = peg$parsex();
+                                                                                                        if (s4 !== peg$FAILED) {
+                                                                                                          s5 = peg$parsea();
+                                                                                                          if (s5 !== peg$FAILED) {
+                                                                                                            s6 = peg$parsei();
+                                                                                                            if (s6 !== peg$FAILED) {
+                                                                                                              s4 = [s4, s5, s6];
+                                                                                                              s3 = s4;
+                                                                                                            } else {
+                                                                                                              peg$currPos = s3;
+                                                                                                              s3 = peg$c0;
+                                                                                                            }
                                                                                                           } else {
                                                                                                             peg$currPos = s3;
                                                                                                             s3 = peg$c0;
@@ -51503,9 +51541,6 @@ var camxes = (function() {
                                                                                                           peg$currPos = s3;
                                                                                                           s3 = peg$c0;
                                                                                                         }
-                                                                                                      } else {
-                                                                                                        peg$currPos = s3;
-                                                                                                        s3 = peg$c0;
                                                                                                       }
                                                                                                     }
                                                                                                   }

--- a/camxes-exp.peg
+++ b/camxes-exp.peg
@@ -1721,7 +1721,7 @@ KEI <- &cmavo ( k e i ) &post_word
 KI <- &cmavo ( k i ) &post_word
 
 #// EXP-ADD: xai
-KOhA <- &cmavo ( n a u h o / d a h u / d a h e / d i h u / d i h e / d e h u / d e h e / d e i / d o h i / m i h o / m i h a i / m a h a / m i h a / d o h o / k o h a / f o h u / k o h e / k o h i / k o h o / k o h u / f o h a / f o h e / f o h i / f o h o / v o h a / v o h e / v o h i / v o h o / v o h u / r u / r i / r a / t a / t u / t i / z i h o / k e h a / m a / z u h i / z o h e / c e h u / d a / d e / d i / k o / m i / d o / x a i) &post_word
+KOhA <- &cmavo ( z u h a i / n a u h o / d a h u / d a h e / d i h u / d i h e / d e h u / d e h e / d e i / d o h i / m i h o / m i h a i / m a h a / m i h a / d o h o / k o h a / f o h u / k o h e / k o h i / k o h o / k o h u / f o h a / f o h e / f o h i / f o h o / v o h a / v o h e / v o h i / v o h o / v o h u / r u / r i / r a / t a / t u / t i / z i h o / k e h a / m a / z u h i / z o h e / c e h u / d a / d e / d i / k o / m i / d o / x a i) &post_word
 
 KU <- &cmavo ( k u ) &post_word
 

--- a/camxes-exp.pegjs
+++ b/camxes-exp.pegjs
@@ -1850,7 +1850,7 @@ KEI = expr:(&cmavo ( k e i ) &post_word) {return _node("KEI", expr);}
 KI = expr:(&cmavo ( k i ) &post_word) {return _node("KI", expr);}
 
 //// EXP-ADD: xai
-KOhA = expr:(&cmavo ( n a u h o / d a h u / d a h e / d i h u / d i h e / d e h u / d e h e / d e i / d o h i / m i h o / m i h a i / m a h a / m i h a / d o h o / k o h a / f o h u / k o h e / k o h i / k o h o / k o h u / f o h a / f o h e / f o h i / f o h o / v o h a / v o h e / v o h i / v o h o / v o h u / r u / r i / r a / t a / t u / t i / z i h o / k e h a / m a / z u h i / z o h e / c e h u / d a / d e / d i / k o / m i / d o / x a i) &post_word) {return _node("KOhA", expr);}
+KOhA = expr:(&cmavo ( z u h a i / n a u h o / d a h u / d a h e / d i h u / d i h e / d e h u / d e h e / d e i / d o h i / m i h o / m i h a i / m a h a / m i h a / d o h o / k o h a / f o h u / k o h e / k o h i / k o h o / k o h u / f o h a / f o h e / f o h i / f o h o / v o h a / v o h e / v o h i / v o h o / v o h u / r u / r i / r a / t a / t u / t i / z i h o / k e h a / m a / z u h i / z o h e / c e h u / d a / d e / d i / k o / m i / d o / x a i) &post_word) {return _node("KOhA", expr);}
 
 KU = expr:(&cmavo ( k u ) &post_word) {return _node("KU", expr);}
 


### PR DESCRIPTION
{zu'ai} is an experimental cmavo of selma'o KOhA that means "each other," so that instead of saying {lo'i re bukpu cu simxu leka ce'u lamji ce'u}, you can simply say, {lo'i re bukpu cu lamji zu'ai}, and it will mean the same thing.