### PR TITLE
Disable input correction attributes

### DIFF
--- a/camxes-dyn.html
+++ b/camxes-dyn.html
@@ -7,7 +7,8 @@
 <br /><br />
 
 <form id="form1" name="form1" method="post" action="" style="width:100%">
-  <textarea id="input_textarea" style="width:100%" rows="8" autofocus></textarea>
+  <textarea id="input_textarea" style="width:100%" rows="8" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" 
+	    autofocus></textarea>
   <br />
   <span style="font: 15px arial, sans-serif;">Output mode: </span>
   <select id="optlist" onChange="run_camxes()">

--- a/camxes-exp.html
+++ b/camxes-exp.html
@@ -12,7 +12,8 @@
 <br /><br />
 
 <form id="form1" name="form1" method="post" action="" style="width:100%">
-  <textarea id="input_textarea" style="width:100%" rows="8" autofocus></textarea>
+  <textarea id="input_textarea" style="width:100%" rows="8" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" 
+	    autofocus></textarea>
   <br />
   <span style="font: 15px arial, sans-serif;">Output mode: </span>
   <select id="optlist" onChange="run_camxes()">

--- a/camxes.html
+++ b/camxes.html
@@ -12,7 +12,8 @@
 <br /><br />
 
 <form id="form1" name="form1" method="post" action="" style="width:100%">
-  <textarea id="input_textarea" style="width:100%" rows="8" autofocus></textarea>
+  <textarea id="input_textarea" style="width:100%" rows="8" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" 
+	    autofocus></textarea>
   <br />
   <span style="font: 15px arial, sans-serif;">Output mode: </span>
   <select id="optlist" onChange="run_camxes()">

--- a/glosser/glosser.htm
+++ b/glosser/glosser.htm
@@ -25,12 +25,12 @@
      <form onsubmit="parse(); return false;">
       <fieldset>
        <!--legend>Type any Lojban text in the following textarea and press "Parse".</legend-->
-       <textarea id="lojban-text-area" rows="5" placeholder='Type any Lojban text in the following textarea and press "Parse".' style="width: 100%;"></textarea>
+       <textarea id="lojban-text-area" rows="5" placeholder='Type any Lojban text in the following textarea and press "Parse".' style="width: 100%;" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false"></textarea>
        <button class="btn btn-primary" onclick="parse(); return false;"><i class="icon-search icon-white"></i> Parse</button>
        <a href="glosser.htm#output-options-modal" class="btn" data-toggle="modal"><i class="icon-wrench"></i> Output options</a>
         <div id="output-options-modal" class="modal hide fade" tabindex="-1" role="dialog">
         <div class="modal-header">
-         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">Ã—</button>
          <h3>Output options</h3>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
Turn off autocomplete, autocapitalise, autocorrect, and spellcheck for the text input boxes. This makes it easier to type lojban text on devices that don't understand lojban text (especially mobile devices).